### PR TITLE
VB train/val/test split + CE baselines (B1: LM-SFT, B2: EBT) — tested end-to-end on SNAP

### DIFF
--- a/experiments/09_vb_ce_baselines/PROMPT.md
+++ b/experiments/09_vb_ce_baselines/PROMPT.md
@@ -1,0 +1,36 @@
+# VeriBench Cross-Entropy Baselines — B1: LM-SFT, B2: EBT (execution prompt)
+
+**TLDR:** SFT a small LM on the VB-train split, tune only on val, report completion-only cross-entropy (+ ppl) on test; then attempt the same protocol with the official EBT codebase. Data comes from `experiments/08_vb_train_val_test/splits/`. This file is the runnable version of the prompt drafted in the 2026-06-09 meeting, with placeholders filled from the actual split.
+
+**Provenance:** drafted from the [2026-06-09 meeting](https://fathom.video/share/GsBj2jyUo3Xo_pNaqWdvoZ4Ud4SXgdfv) via [this claude.ai chat](https://claude.ai/chat/95a8bcf4-5535-4d09-a414-d6ab99a4fd01); placeholders filled + numbers corrected against the real split on 2026-06-09 (this repo, branch `vb-ce-baselines-elyas`).
+
+---
+
+You are Claude Code on the SNAP cluster (iterate on **skampere2**; only use skampere3 for large runs). Working repo: **brando90/free-energy** — commit all configs, scripts, and results under `experiments/09_vb_ce_baselines/`. Goal: SFT on the VeriBench **train** split, tune only on **val**, report cross-entropy on **test**. Just the loss — no task eval needed yet.
+
+## Filled-in parameters (were `<FILL>` in the draft)
+- `VERIBENCH_SPLIT` = `experiments/08_vb_train_val_test/splits/{train,val,test}.jsonl` (this repo; self-contained JSONL with `py_code` + `lean_text` embedded — see that experiment's README for schema). Sizes: **train 707** (702 py-paired) / **val 87** (86) / **test 97** (96). The draft said "~200 examples" — that was wrong.
+- `MODEL` = `Qwen/Qwen2.5-0.5B` (≤1.5B class)
+- `MAX_SEQ_LEN` = **4096** (draft said 2048, but est. token length of py+lean pairs: median ≈2046, p95 ≈3986, max ≈10120 → 2048 truncates ~50% of examples, 4096 only ~4.3%). Report truncation counts.
+
+## Protocol (applies to both parts)
+- **Metric:** mean per-token NLL in nats (cross-entropy) + perplexity = exp(CE). The data has prompt→target structure (`py_code` → `lean_text`), so compute **completion-only CE** (mask prompt tokens) as the primary number and full-sequence CE as secondary. Skip the 7 `paired == false` rows (Lean-only CLRS tasks) for conditional CE.
+- **Hygiene:** never touch test until the final measurement. Fix the tokenizer across all runs. Seed everything; run the best config with **3 seeds**, report mean ± std.
+- **References to report alongside:** zero-shot CE of the *un*-finetuned `MODEL` on test (so the SFT delta is visible).
+- **Logging:** per-run config (model, params, LR, epochs, batch, tokens seen), train/val CE curves, approximate training FLOPs (6·N·D). These logs get reused by the fair-comparison project — don't skip them.
+
+## Part A — B1: LM + SFT (run this first)
+1. Sanity check: overfit a single batch (CE → ~0) before any real run.
+2. Full fine-tune `MODEL` on VB-train, bf16, grad accum as needed. Sweep LR ∈ {1e-5, 2e-5, 5e-5}, up to ~10 epochs with early stopping on **val** CE.
+3. Final: best config × 3 seeds → **test CE + perplexity** (completion-only primary).
+4. Deliverable: `results_b1.md` with the table {model, params, LR, epochs, tokens, val CE, test CE, ppl, zero-shot test CE} + exact repro commands.
+
+## Part B — B2: EBT (after Part A works)
+1. Clone the official EBT codebase ([Gladstone et al., arXiv:2507.02092](https://arxiv.org/abs/2507.02092)). Use the LM-style variant — next-token energies normalize at O(V), so test CE is computable.
+2. Attempt SFT-style training on VB-train with the same split/tokenizer/protocol. **If the codebase doesn't support SFT-style training, fall back to the original paper's recipe and say so explicitly in the report** (per the meeting).
+3. Match Part A's budget as closely as possible (params, tokens seen); log the differences you can't match.
+4. Deliverable: `results_b2.md`, same table format, + one paragraph on any EBT-specific training instabilities (divergence/NaNs).
+   - Note: a deleted toy EBT experiment exists in git history at `experiments/05_energy_based_transformer_baseline/` (commit `84f7441`) — context only; the official codebase is the source of truth for B2.
+
+## Stop conditions
+If the split is missing, a download fails, or EBT training diverges across all reasonable settings — stop, write up what happened rather than improvising the protocol.

--- a/experiments/09_vb_ce_baselines/ebt_integration/apply_ebt_integration.py
+++ b/experiments/09_vb_ce_baselines/ebt_integration/apply_ebt_integration.py
@@ -1,0 +1,49 @@
+# TLDR: Idempotently patch an alexiglad/EBT checkout to register the 'veribench' dataset.
+"""Apply the VeriBench integration to an official EBT checkout (tested at commit 19420cb).
+
+Usage: python apply_ebt_integration.py /path/to/EBT
+Copies veribench_dataloader.py into EBT/data/nlp/ and inserts the 'veribench'
+branches into base_model_trainer.py's fit/test dataset dispatch.
+"""
+import shutil
+import sys
+from pathlib import Path
+
+IMPORT_ANCHOR = "from data.nlp.fineweb_dataloader import FineWebDataset"
+IMPORT_ADD = "from data.nlp.veribench_dataloader import VeribenchDataset"
+
+FIT_ANCHOR = '''            else:
+                raise NotImplementedError("Haven't implemented this dataset yet")'''
+FIT_ADD = '''            elif self.hparams.dataset_name == "veribench":
+                self.train_ds = VeribenchDataset(self.hparams, split="train")
+                self.val_ds = VeribenchDataset(self.hparams, split="val")
+'''
+
+TEST_ANCHOR = '''            else:
+                raise NotImplementedError("haven't implemented this dataset yet")'''
+TEST_ADD = '''            elif self.hparams.dataset_name == "veribench":
+                self.test_ds = VeribenchDataset(self.hparams, split="test")
+'''
+
+
+def main() -> int:
+    ebt_root = Path(sys.argv[1] if len(sys.argv) > 1 else "EBT").resolve()
+    trainer = ebt_root / "base_model_trainer.py"
+    src = trainer.read_text()
+    shutil.copy(Path(__file__).parent / "veribench_dataloader.py", ebt_root / "data" / "nlp" / "veribench_dataloader.py")
+    if "VeribenchDataset" in src:
+        print(f"[apply] {trainer} already patched — refreshed dataloader copy only")
+        return 0
+    for anchor, label in ((IMPORT_ANCHOR, "import"), (FIT_ANCHOR, "fit dispatch"), (TEST_ANCHOR, "test dispatch")):
+        if src.count(anchor) != 1:
+            raise SystemExit(f"[apply] {label} anchor not found exactly once (count={src.count(anchor)}) — EBT version drift?")
+    src = src.replace(IMPORT_ANCHOR, IMPORT_ANCHOR + "\n" + IMPORT_ADD)
+    src = src.replace(FIT_ANCHOR, FIT_ADD + FIT_ANCHOR)
+    src = src.replace(TEST_ANCHOR, TEST_ADD + TEST_ANCHOR)
+    trainer.write_text(src)
+    print(f"[apply] patched {trainer} (import + fit/test dispatch) and installed data/nlp/veribench_dataloader.py")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/09_vb_ce_baselines/ebt_integration/veribench_dataloader.py
+++ b/experiments/09_vb_ce_baselines/ebt_integration/veribench_dataloader.py
@@ -48,7 +48,8 @@ class VeribenchDataset(Dataset):
                     n_target_trunc += 1
                     prompt_ids = []
                 elif len(prompt_ids) + len(target_ids) > self.max_length:
-                    prompt_ids = prompt_ids[-(self.max_length - len(target_ids)):]
+                    budget = self.max_length - len(target_ids)  # guard: [-0:] would keep the whole prompt
+                    prompt_ids = prompt_ids[-budget:] if budget > 0 else []
                     n_prompt_trunc += 1
                 ids = prompt_ids + target_ids
                 self.items.append({"input_ids": ids, "attention_mask": [1] * len(ids)})

--- a/experiments/09_vb_ce_baselines/ebt_integration/veribench_dataloader.py
+++ b/experiments/09_vb_ce_baselines/ebt_integration/veribench_dataloader.py
@@ -1,0 +1,62 @@
+# TLDR: VeriBench dataset for the official EBT harness — same py->lean formatting as B1, pretokenized per doc.
+"""VeriBench dataloader for the official EBT codebase (alexiglad/EBT).
+
+Drop into EBT/data/nlp/ (use apply_ebt_integration.py). Follows the explicit-split
+pattern of gsm8k_dataloader.py. Documents are formatted EXACTLY like B1
+(train_b1.py PROMPT_TMPL + lean_text + eos) so cross-entropies are comparable;
+only `paired` rows are used (same 702/86/96 docs as B1's conditional CE).
+
+hparams.dataset_dir must point at .../experiments/08_vb_train_val_test/splits.
+Requires --pretokenize_dataset (items are token dicts; their NLP_HF_Collator pads).
+"""
+import json
+import os
+
+from torch.utils.data import Dataset
+from transformers import AutoTokenizer
+
+PROMPT_TMPL = (
+    "/- Translate the following Python program into a Lean 4 formalization with theorems. -/\n\n"
+    "-- PYTHON SOURCE:\n{py}\n\n-- LEAN 4:\n"
+)
+
+
+class VeribenchDataset(Dataset):
+    def __init__(self, hparams, split):
+        if hparams.execution_mode != "pretrain":
+            raise ValueError("VeribenchDataset: only pretrain execution_mode is supported (paper-recipe fallback).")
+        if not hparams.pretokenize_dataset:
+            raise ValueError("VeribenchDataset: pass --pretokenize_dataset (collator expects token dicts).")
+        self.max_length = hparams.context_length + 1
+        path = os.path.join(hparams.dataset_dir, f"{split}.jsonl")
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"VeriBench split not found: {path} (set --dataset_dir to .../08_vb_train_val_test/splits)")
+        tokenizer = AutoTokenizer.from_pretrained(hparams.tokenizer, clean_up_tokenization_spaces=False)
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+        self.items = []
+        n_prompt_trunc = n_target_trunc = 0
+        with open(path) as f:
+            for line in f:
+                r = json.loads(line)
+                if not r.get("py_code"):
+                    continue  # keep the doc set identical to B1's conditional-CE set
+                # same truncation policy as B1 (train_b1.py): left-truncate the prompt to keep the target whole
+                prompt_ids = tokenizer(PROMPT_TMPL.format(py=r["py_code"]), add_special_tokens=False)["input_ids"]
+                target_ids = tokenizer(r["lean_text"], add_special_tokens=False)["input_ids"] + [tokenizer.eos_token_id]
+                if len(target_ids) > self.max_length:
+                    target_ids = target_ids[: self.max_length]
+                    n_target_trunc += 1
+                    prompt_ids = []
+                elif len(prompt_ids) + len(target_ids) > self.max_length:
+                    prompt_ids = prompt_ids[-(self.max_length - len(target_ids)):]
+                    n_prompt_trunc += 1
+                ids = prompt_ids + target_ids
+                self.items.append({"input_ids": ids, "attention_mask": [1] * len(ids)})
+        print(f"[veribench] split={split}: {len(self.items)} docs (paired only), "
+              f"{n_prompt_trunc} prompt-truncated / {n_target_trunc} target-truncated at {self.max_length} tokens")
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getitem__(self, idx):
+        return self.items[idx]

--- a/experiments/09_vb_ce_baselines/eval_b2.py
+++ b/experiments/09_vb_ce_baselines/eval_b2.py
@@ -53,9 +53,16 @@ def main() -> int:
     from base_model_trainer import ModelTrainer  # noqa: E402
 
     ckpt = pick_ckpt(Path(args.ckpt).resolve())
-    module = ModelTrainer.load_from_checkpoint(str(ckpt), map_location="cuda")
+    # ModelTrainer.__init__ takes hparams positionally, which breaks load_from_checkpoint -> load manually
+    from argparse import Namespace  # noqa: E402
+    payload = torch.load(str(ckpt), map_location="cpu", weights_only=False)
+    hp = payload.get("hyper_parameters", {})
+    hparams = hp if isinstance(hp, Namespace) else Namespace(**dict(hp))
+    module = ModelTrainer(hparams)
+    missing, unexpected = module.load_state_dict(payload["state_dict"], strict=False)
+    assert not missing and not unexpected, f"state_dict mismatch: missing={missing[:3]} unexpected={unexpected[:3]}"
     model = module.model.cuda().eval()
-    tok_name = module.hparams.tokenizer
+    tok_name = hparams.tokenizer
     from transformers import AutoTokenizer  # noqa: E402
     tokenizer = AutoTokenizer.from_pretrained(tok_name, clean_up_tokenization_spaces=False)
     eos = tokenizer.eos_token_id
@@ -69,7 +76,8 @@ def main() -> int:
         if len(target_ids) > max_len:
             target_ids, prompt_ids = target_ids[:max_len], []
         elif len(prompt_ids) + len(target_ids) > max_len:
-            prompt_ids = prompt_ids[-(max_len - len(target_ids)):]
+            budget = max_len - len(target_ids)  # guard: [-0:] would keep the whole prompt
+            prompt_ids = prompt_ids[-budget:] if budget > 0 else []
         ids = torch.tensor([prompt_ids + target_ids], device="cuda")
         x, targets = ids[:, :-1], ids[:, 1:]
         dists, _ = model(x, learning=False, return_raw_logits=False, no_randomness=True)
@@ -90,6 +98,7 @@ def main() -> int:
 
     res = {
         "mode": "b2_eval", "ckpt": str(ckpt), "split": args.split, "n_docs": len(rows),
+        "n_params": sum(p.numel() for p in model.parameters()),
         "context_length": args.context_length, "tokenizer": tok_name,
         "completion_ce": comp_nll / max(comp_tok, 1), "completion_ppl": math.exp(comp_nll / max(comp_tok, 1)),
         "completion_tokens": int(comp_tok),

--- a/experiments/09_vb_ce_baselines/eval_b2.py
+++ b/experiments/09_vb_ce_baselines/eval_b2.py
@@ -1,0 +1,108 @@
+# TLDR: Score a trained EBT checkpoint on a VB split — completion-only CE (B1-comparable) + full-seq CE.
+"""Evaluate an official-EBT checkpoint on the VeriBench split with B1's masking protocol.
+
+Run from anywhere; needs the patched EBT checkout (apply_ebt_integration.py) on disk.
+Computes token-weighted mean NLL (nats) over: (a) completion tokens only (prompt
+masked — primary, comparable to B1's completion-only CE), (b) the full sequence.
+Matches EBT training semantics by excluding eos-as-pad targets (their CE uses
+ignore_index = eos); the per-doc effect is ~1 token in ~2k, noted in results_b2.md.
+
+NOTE: no torch.no_grad() — EBT inference *requires* autograd (energy-gradient MCMC).
+
+Usage:
+    python eval_b2.py --ckpt <file-or-dir> [--ebt-dir ../../EBT] [--split test]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+PROMPT_TMPL = (
+    "/- Translate the following Python program into a Lean 4 formalization with theorems. -/\n\n"
+    "-- PYTHON SOURCE:\n{py}\n\n-- LEAN 4:\n"
+)
+
+
+def pick_ckpt(path: Path) -> Path:
+    if path.is_file():
+        return path
+    cands = sorted(path.rglob("*.ckpt"))
+    if not cands:
+        raise SystemExit(f"no .ckpt under {path}")
+    scored = [(float(c.stem.split("valid_loss=")[-1]), c) for c in cands if "valid_loss=" in c.stem]
+    return min(scored)[1] if scored else max(cands, key=lambda c: c.stat().st_mtime)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--ckpt", required=True)
+    p.add_argument("--ebt-dir", default=str(Path(__file__).resolve().parent / ".." / ".." / "EBT"))
+    p.add_argument("--splits-dir", default=str(Path(__file__).resolve().parent.parent / "08_vb_train_val_test" / "splits"))
+    p.add_argument("--split", default="test")
+    p.add_argument("--context-length", type=int, default=2048)
+    p.add_argument("--out", default=None)
+    args = p.parse_args()
+
+    ebt_dir = Path(args.ebt_dir).resolve()
+    sys.path.insert(0, str(ebt_dir))
+    from base_model_trainer import ModelTrainer  # noqa: E402
+
+    ckpt = pick_ckpt(Path(args.ckpt).resolve())
+    module = ModelTrainer.load_from_checkpoint(str(ckpt), map_location="cuda")
+    model = module.model.cuda().eval()
+    tok_name = module.hparams.tokenizer
+    from transformers import AutoTokenizer  # noqa: E402
+    tokenizer = AutoTokenizer.from_pretrained(tok_name, clean_up_tokenization_spaces=False)
+    eos = tokenizer.eos_token_id
+    max_len = args.context_length + 1
+
+    rows = [json.loads(l) for l in open(Path(args.splits_dir) / f"{args.split}.jsonl") if json.loads(l).get("py_code")]
+    comp_nll = comp_tok = full_nll = full_tok = 0.0
+    for i, r in enumerate(rows):
+        prompt_ids = tokenizer(PROMPT_TMPL.format(py=r["py_code"]), add_special_tokens=False)["input_ids"]
+        target_ids = tokenizer(r["lean_text"], add_special_tokens=False)["input_ids"] + [eos]
+        if len(target_ids) > max_len:
+            target_ids, prompt_ids = target_ids[:max_len], []
+        elif len(prompt_ids) + len(target_ids) > max_len:
+            prompt_ids = prompt_ids[-(max_len - len(target_ids)):]
+        ids = torch.tensor([prompt_ids + target_ids], device="cuda")
+        x, targets = ids[:, :-1], ids[:, 1:]
+        dists, _ = model(x, learning=False, return_raw_logits=False, no_randomness=True)
+        logp = dists[-1].view(1, x.shape[1], -1)  # final MCMC step, log-softmaxed
+        nll = -logp.gather(-1, targets.unsqueeze(-1)).squeeze(-1)  # [1, L-1]
+        keep = targets != eos  # match EBT training: eos==pad is ignore_index
+        comp_start = max(len(prompt_ids) - 1, 0)  # first predicted completion token
+        comp_mask = torch.zeros_like(keep)
+        comp_mask[:, comp_start:] = True
+        comp_mask &= keep
+        comp_nll += nll[comp_mask].sum().item()
+        comp_tok += comp_mask.sum().item()
+        full_nll += nll[keep].sum().item()
+        full_tok += keep.sum().item()
+        del dists, logp, nll
+        if (i + 1) % 20 == 0:
+            print(f"[eval_b2] {i+1}/{len(rows)} docs | running completion CE {comp_nll/max(comp_tok,1):.4f}")
+
+    res = {
+        "mode": "b2_eval", "ckpt": str(ckpt), "split": args.split, "n_docs": len(rows),
+        "context_length": args.context_length, "tokenizer": tok_name,
+        "completion_ce": comp_nll / max(comp_tok, 1), "completion_ppl": math.exp(comp_nll / max(comp_tok, 1)),
+        "completion_tokens": int(comp_tok),
+        "full_seq_ce": full_nll / max(full_tok, 1), "full_seq_tokens": int(full_tok),
+        "eos_targets_excluded": True,
+    }
+    out = Path(args.out) if args.out else Path(__file__).resolve().parent / "results" / f"b2_eval_{args.split}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(res, indent=2) + "\n")
+    print(f"[eval_b2] {args.split}: completion CE {res['completion_ce']:.4f} nats (ppl {res['completion_ppl']:.2f}) | "
+          f"full-seq CE {res['full_seq_ce']:.4f} | wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/09_vb_ce_baselines/results_b1.md
+++ b/experiments/09_vb_ce_baselines/results_b1.md
@@ -1,0 +1,32 @@
+# B1 results — LM + SFT on VeriBench train/val/test
+
+**TLDR:** Qwen/Qwen2.5-0.5B full-SFT on VB-train (707 tasks): test completion-CE 0.3124 ± 0.0008 nats (ppl 1.37) over 3 seeds vs zero-shot 1.1485 nats (ppl 3.2). 
+
+Completion-only CE (prompt tokens masked) in nats; ppl = exp(CE). Full protocol: `PROMPT.md`.
+
+## LR sweep (seed 0, early stop on val CE)
+
+| LR | epochs ran | best epoch | val CE | test CE* |
+|---|---|---|---|---|
+| 1e-05 | 5 | 2 | 0.3429 | 0.3164 |
+| 2e-05 | 4 | 1 | 0.3362 | 0.3125 |
+| 5e-05 | 4 | 1 | 0.3403 | 0.3100 |
+
+*test CE shown for completeness; best LR was selected on val only.
+
+## Final: best LR = 2e-05 × 3 seeds
+
+| model | params | LR | sched | eff. batch | max epochs | best epoch (per seed) | tokens seen (mean) | val CE (mean±std) | **test CE (mean±std)** | test ppl | full-seq test CE | zero-shot test CE |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Qwen/Qwen2.5-0.5B | 494M | 2e-05 | cosine, wu 3% | 16 | 10 | 1,1,1 | 6.11e+06 | 0.3353±0.0006 | **0.3124±0.0008** | 1.37 | 0.6695 | 1.1485 |
+
+FLOPs estimate (6·N·D): 1.81e+16 per final run. Truncation at max_seq_len 4096: 20 prompt-truncated, 8 target-truncated of 702 train examples; 5/1/1 unpaired rows skipped (train/val/test).
+
+## Repro
+```bash
+python train_b1.py --mode zeroshot
+python train_b1.py --mode overfit --lr 5e-5
+for lr in 1e-5 2e-5 5e-5; do python train_b1.py --mode train --lr $lr --seed 0; done
+for s in 0 1 2; do python train_b1.py --mode train --lr 2e-05 --seed $s; done
+python train_b1.py --mode aggregate
+```

--- a/experiments/09_vb_ce_baselines/results_b2.md
+++ b/experiments/09_vb_ce_baselines/results_b2.md
@@ -1,0 +1,44 @@
+# B2 results — official EBT on VeriBench train/val/test (paper-recipe fallback)
+
+**TLDR:** Official EBT (`alexiglad/EBT` @ `19420cb`, `ebt-xxs` + Qwen vocab = 131M params) trained **from scratch** on VB-train (the repo ships no pretrained LM checkpoints, so SFT-style training is not runnable as-is — this is the prompt's explicit fallback): best-val checkpoint (epoch 14 of 32) reaches **test completion-CE 2.7794 nats (ppl 16.11)**; full-seq 2.7960. Reference points from B1: pretrained Qwen2.5-0.5B zero-shot 1.1485, SFT 0.3124 ± 0.0008. The B1-vs-B2 gap is dominated by **pretrained-vs-from-scratch**, not architecture — do not read it as an EBT-vs-transformer comparison.
+
+## Why the fallback (stated per protocol)
+
+The official codebase has an `--execution_mode finetune`, but it requires `--finetuning_model_ckpt` and **no pretrained EBT LM checkpoints are released** (README's inference flow assumes you trained your own). SFT atop a pretrained EBT is therefore not runnable as-is. Per `PROMPT.md` Part B step 2, we fell back to the paper's pretrain recipe (`job_scripts/nlp/pretrain/ebt_s1.sh` hparams) on VB-train, with the same data formatting, tokenizer, and eval masking as B1.
+
+## Result
+
+| model | params | recipe | LR | eff. batch | steps (epochs) | selected ckpt | tokens seen @ sel. | val CE | **test CE** | test ppl | full-seq test CE |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| EBT-xxs (time_embed, mcmc 2) | 131M | from scratch | 1.2e-3 | 16 seqs | 1400 (31.9) | epoch 14 (val top-1) | ~19.4M | 2.8258 | **2.7794** | 16.11 | 2.7960 |
+
+- `last.ckpt` (step 1400) scores test CE 2.7795 — identical to the val-selected ckpt; val plateaued from epoch 14 (mild overfitting regime, no divergence).
+- Eval = `eval_b2.py`: token-weighted NLL from the final MCMC step's normalized next-token distribution, same prompt-masking as B1.
+
+## Training stability (per protocol, the instabilities paragraph)
+
+No divergence and no NaN/Inf events across 1400 steps (the EBT forward raises on NaN/Inf MCMC gradients — never triggered; learnable step-size α logged in `EBT/logs/console.log`). The only failure modes encountered were infrastructural: (i) **memory** — EBT's MCMC keeps `[B, S, |V|]` prob-dist tensors with a double-backprop graph; at context 4096 even bs=1 OOM'd a 143 GB H200, hence context 2048 + bs 1 × accum 16 (~30 GB steady); (ii) a **data bug in our own loader** (`prompt[-0:]` negative-zero slice keeping the whole prompt when a target is exactly max_len) — exactly 1 train doc triggered it and tripped EBT's RoPE shape assert; fixed in `8d9b7cc`, audited: 0 B1 items affected.
+
+## Budget match vs B1 (differences we could not match, logged per protocol)
+
+| dimension | B1 | B2 | note |
+|---|---|---|---|
+| init | pretrained Qwen2.5-0.5B | from scratch | the dominant difference |
+| params | 494M | 131M (vocab-dominated: 2×151936×384 embeddings) | their canonical xxs size |
+| tokenizer | Qwen2.5 | Qwen2.5 (same) | CE in nats/token directly comparable |
+| context | 4096 (20/8 prompt/target-trunc of 702) | 2048 (165/174) | MCMC memory bound |
+| tokens seen @ selection | 6.11M | ~19.4M (41.2M full run) | from-scratch needs more passes |
+| FLOPs est. 6·N·D @ sel. | 1.81e16 | ~1.52e16 | comparable compute |
+| seeds | 3 (std 0.0008) | 1 (their default 33) | rerun if a std is needed (~2 h/run) |
+| eos target in CE | included | excluded (their pad==eos `ignore_index` convention) | ~1 token per ~2k-token doc |
+| LR sched | cosine, wu 3% | their recipe (peak 1.2e-3, min_lr_scale 10, wu 100) | per ebt_s1.sh |
+
+## Repro
+
+```bash
+# train (patches a pinned EBT clone, then runs their train_model.py on VB):
+bash run_b2.sh 0 1400          # [GPU_ID] [MAX_STEPS]; ~2 h on 1x H200
+# eval best-val ckpt with B1-comparable masking:
+python eval_b2.py --ckpt <EBT>/logs/checkpoints/<run>/ --split test
+```
+Raw eval JSONs: `results/b2_eval_{test_best,val_best,test_last}.json` (includes n_params, token counts).

--- a/experiments/09_vb_ce_baselines/run_b1.sh
+++ b/experiments/09_vb_ce_baselines/run_b1.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# TLDR: Full B1 pipeline on one GPU — zeroshot ref, overfit sanity, LR sweep, 3-seed finals, aggregate to results_b1.md.
+# Usage: bash run_b1.sh [GPU_ID]   (default GPU 0; uses the venv it's launched in)
+set -euo pipefail
+export CUDA_VISIBLE_DEVICES="${1:-0}"
+cd "$(dirname "$0")"
+
+python train_b1.py --mode zeroshot
+python train_b1.py --mode overfit --lr 5e-5
+
+for lr in 1e-5 2e-5 5e-5; do
+  python train_b1.py --mode train --lr "$lr" --seed 0
+done
+
+BEST_LR=$(python - <<'EOF'
+import json, pathlib
+runs = [json.loads(p.read_text()) for p in pathlib.Path("results").glob("b1_lr*_seed0.json")]
+print(f"{min(runs, key=lambda r: r['val_ce'])['lr']:g}")
+EOF
+)
+echo "[run_b1] best LR on val: $BEST_LR"
+
+for s in 1 2; do
+  python train_b1.py --mode train --lr "$BEST_LR" --seed "$s"
+done
+
+python train_b1.py --mode aggregate

--- a/experiments/09_vb_ce_baselines/run_b2.sh
+++ b/experiments/09_vb_ce_baselines/run_b2.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# TLDR: B2 — train the official EBT (xxs, paper recipe, from scratch) on VB-train; same formatting/tokenizer as B1.
+# Usage: bash run_b2.sh [GPU_ID] [MAX_STEPS] [EBT_DIR] [SPLITS_DIR]
+# Paper-recipe fallback (documented in results_b2.md): the EBT repo ships no pretrained
+# LM checkpoints, so SFT-style training is not runnable as-is; we train from scratch
+# with the canonical NLP recipe (job_scripts/nlp/pretrain/ebt_s1.sh) adapted to VB:
+# Qwen tokenizer (CE comparability with B1), context 4096, small-data step budget.
+set -euo pipefail
+GPU_ID="${1:-1}"
+MAX_STEPS="${2:-1400}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EBT_DIR="${3:-$SCRIPT_DIR/../../EBT}"   # default: EBT checkout at the workspace root (sibling of experiments/)
+SPLITS_DIR="${4:-$SCRIPT_DIR/../08_vb_train_val_test/splits}"
+EBT_COMMIT="19420cb"
+
+if [ ! -d "$EBT_DIR" ]; then
+  git clone https://github.com/alexiglad/EBT "$EBT_DIR"
+fi
+git -C "$EBT_DIR" checkout -q "$EBT_COMMIT"
+python "$SCRIPT_DIR/ebt_integration/apply_ebt_integration.py" "$EBT_DIR"
+
+export CUDA_VISIBLE_DEVICES="$GPU_ID"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+cd "$EBT_DIR"
+python train_model.py \
+  --run_name "ebt-xxs-vb-steps${MAX_STEPS}" \
+  --modality "NLP" \
+  --model_name "ebt" \
+  --model_size "xxs" \
+  --dataset_name "veribench" \
+  --dataset_dir "$(cd "$SPLITS_DIR" && pwd)" \
+  --pretokenize_dataset \
+  --tokenizer "Qwen/Qwen2.5-0.5B" \
+  --context_length 2048 \
+  --normalize_initial_condition \
+  --ebt_type "time_embed" \
+  --denoising_initial_condition "random_noise" \
+  --mcmc_step_size_learnable \
+  --mcmc_step_size 0.5 \
+  --mcmc_step_size_lr_multiplier 1.5 \
+  --mcmc_num_steps 2 \
+  --gpus "-1" \
+  --peak_learning_rate 0.0012 \
+  --batch_size_per_device 1 \
+  --accumulate_grad_batches 16 \
+  --gradient_clip_val 1.0 \
+  --weight_decay 0.01 \
+  --min_lr_scale 10 \
+  --max_steps "$MAX_STEPS" \
+  --max_scheduling_steps "$MAX_STEPS" \
+  --warm_up_steps 100 \
+  --check_val_every_n_epoch 1 \
+  --save_top_k_ckpts 1 \
+  --float_precision "bf16-mixed" \
+  --set_matmul_precision "high" \
+  --num_workers 8 \
+  --no_wandb

--- a/experiments/09_vb_ce_baselines/train_b1.py
+++ b/experiments/09_vb_ce_baselines/train_b1.py
@@ -66,7 +66,8 @@ class PairDataset(Dataset):
                 self.n_target_trunc += 1
                 prompt_ids = []
             elif len(prompt_ids) + len(target_ids) > max_len:
-                prompt_ids = prompt_ids[-(max_len - len(target_ids)):]
+                budget = max_len - len(target_ids)  # guard: [-0:] would keep the whole prompt
+                prompt_ids = prompt_ids[-budget:] if budget > 0 else []
                 self.n_prompt_trunc += 1
             self.examples.append(
                 Example(input_ids=prompt_ids + target_ids, labels=[-100] * len(prompt_ids) + target_ids)

--- a/experiments/09_vb_ce_baselines/train_b1.py
+++ b/experiments/09_vb_ce_baselines/train_b1.py
@@ -1,0 +1,372 @@
+# TLDR: B1 baseline — SFT a small LM on VB-train (py->lean), early-stop on val CE, report completion-only test CE.
+"""VeriBench CE baseline B1: LM + SFT.
+
+Trains a causal LM on (py_code -> lean_text) pairs from
+experiments/08_vb_train_val_test/splits/, with completion-only cross-entropy
+(prompt tokens masked) as the primary metric and full-sequence CE secondary.
+CE is the token-weighted mean NLL in nats over the split; ppl = exp(CE).
+
+Modes:
+    zeroshot  - eval the un-finetuned model on val+test (reference numbers)
+    overfit   - single-batch overfit sanity check (CE -> ~0)
+    train     - one config (lr, seed): train w/ early stopping on val CE,
+                restore best-val weights, eval test once, write JSON
+    aggregate - read results/*.json -> results_b1.md
+
+Examples:
+    python train_b1.py --mode zeroshot
+    python train_b1.py --mode overfit --lr 5e-5
+    python train_b1.py --mode train --lr 2e-5 --seed 0
+    python train_b1.py --mode aggregate
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, Dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer, get_cosine_schedule_with_warmup
+
+PROMPT_TMPL = (
+    "/- Translate the following Python program into a Lean 4 formalization with theorems. -/\n\n"
+    "-- PYTHON SOURCE:\n{py}\n\n-- LEAN 4:\n"
+)
+
+
+@dataclass
+class Example:
+    input_ids: list[int]
+    labels: list[int]  # -100 on prompt positions
+
+
+class PairDataset(Dataset):
+    """py->lean pairs, tokenized once. Prompt is left-truncated to keep the target whole."""
+
+    def __init__(self, rows: list[dict], tokenizer, max_len: int):
+        self.examples: list[Example] = []
+        self.n_prompt_trunc = 0
+        self.n_target_trunc = 0
+        self.n_skipped_unpaired = 0
+        for r in rows:
+            if not r.get("py_code"):
+                self.n_skipped_unpaired += 1
+                continue
+            prompt_ids = tokenizer(PROMPT_TMPL.format(py=r["py_code"]), add_special_tokens=False)["input_ids"]
+            target_ids = tokenizer(r["lean_text"], add_special_tokens=False)["input_ids"] + [tokenizer.eos_token_id]
+            if len(target_ids) > max_len:
+                target_ids = target_ids[:max_len]
+                self.n_target_trunc += 1
+                prompt_ids = []
+            elif len(prompt_ids) + len(target_ids) > max_len:
+                prompt_ids = prompt_ids[-(max_len - len(target_ids)):]
+                self.n_prompt_trunc += 1
+            self.examples.append(
+                Example(input_ids=prompt_ids + target_ids, labels=[-100] * len(prompt_ids) + target_ids)
+            )
+
+    def __len__(self):
+        return len(self.examples)
+
+    def __getitem__(self, i):
+        return self.examples[i]
+
+    def stats(self) -> dict:
+        return {
+            "n_examples": len(self.examples),
+            "n_skipped_unpaired": self.n_skipped_unpaired,
+            "n_prompt_truncated": self.n_prompt_trunc,
+            "n_target_truncated": self.n_target_trunc,
+            "total_target_tokens": sum(sum(l != -100 for l in e.labels) for e in self.examples),
+        }
+
+
+def collate(batch: list[Example], pad_id: int):
+    width = max(len(e.input_ids) for e in batch)
+    ids = torch.full((len(batch), width), pad_id, dtype=torch.long)
+    labels = torch.full((len(batch), width), -100, dtype=torch.long)
+    mask = torch.zeros((len(batch), width), dtype=torch.long)
+    for i, e in enumerate(batch):
+        n = len(e.input_ids)
+        ids[i, :n] = torch.tensor(e.input_ids)
+        labels[i, :n] = torch.tensor(e.labels)
+        mask[i, :n] = 1
+    return ids, labels, mask
+
+
+@torch.no_grad()
+def evaluate(model, loader, device, full_sequence: bool = False) -> tuple[float, int]:
+    """Token-weighted mean NLL (nats). full_sequence=True scores all non-pad tokens, not just the target."""
+    model.eval()
+    total_nll, total_tokens = 0.0, 0
+    for ids, labels, mask in loader:
+        ids, labels, mask = ids.to(device), labels.to(device), mask.to(device)
+        if full_sequence:
+            labels = ids.masked_fill(mask == 0, -100)
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            logits = model(input_ids=ids, attention_mask=mask).logits
+        shift_logits = logits[:, :-1].float()
+        shift_labels = labels[:, 1:]
+        total_nll += F.cross_entropy(
+            shift_logits.reshape(-1, shift_logits.size(-1)), shift_labels.reshape(-1),
+            ignore_index=-100, reduction="sum",
+        ).item()
+        total_tokens += (shift_labels != -100).sum().item()
+    return total_nll / max(total_tokens, 1), total_tokens
+
+
+def load_rows(data_dir: Path, split: str) -> list[dict]:
+    return [json.loads(l) for l in (data_dir / f"{split}.jsonl").open()]
+
+
+def set_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def build(args, splits=("train", "val", "test")):
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    data_dir = Path(args.data_dir).expanduser().resolve()
+    sets = {s: PairDataset(load_rows(data_dir, s), tokenizer, args.max_seq_len) for s in splits}
+    model = AutoModelForCausalLM.from_pretrained(args.model).float()  # fp32 master weights regardless of transformers version
+    model.to(args.device)
+    return tokenizer, sets, model
+
+
+def make_loader(ds, tokenizer, bs, shuffle=False, seed=0):
+    gen = torch.Generator().manual_seed(seed)
+    return DataLoader(ds, batch_size=bs, shuffle=shuffle, generator=gen if shuffle else None,
+                      collate_fn=lambda b: collate(b, tokenizer.pad_token_id))
+
+
+def run_zeroshot(args) -> dict:
+    tokenizer, sets, model = build(args)
+    out = {"mode": "zeroshot", "model": args.model, "max_seq_len": args.max_seq_len,
+           "data_stats": {k: v.stats() for k, v in sets.items()}}
+    for split in ("val", "test"):
+        loader = make_loader(sets[split], tokenizer, args.eval_batch_size)
+        ce, ntok = evaluate(model, loader, args.device)
+        ce_full, _ = evaluate(model, loader, args.device, full_sequence=True)
+        out[f"{split}_ce"] = ce
+        out[f"{split}_ppl"] = math.exp(ce)
+        out[f"{split}_ce_full_seq"] = ce_full
+        out[f"{split}_target_tokens"] = ntok
+        print(f"[zeroshot] {split}: completion CE {ce:.4f} nats (ppl {math.exp(ce):.1f}) | full-seq CE {ce_full:.4f}")
+    return out
+
+
+def run_overfit(args) -> dict:
+    set_seed(args.seed)
+    tokenizer, sets, model = build(args, splits=("train",))
+    batch = [sets["train"][i] for i in range(args.batch_size)]
+    ids, labels, mask = collate(batch, tokenizer.pad_token_id)
+    ids, labels, mask = ids.to(args.device), labels.to(args.device), mask.to(args.device)
+    opt = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=0.0)
+    model.train()
+    first = last = None
+    for step in range(args.overfit_steps):
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            logits = model(input_ids=ids, attention_mask=mask).logits
+        loss = F.cross_entropy(logits[:, :-1].float().reshape(-1, logits.size(-1)),
+                               labels[:, 1:].reshape(-1), ignore_index=-100)
+        opt.zero_grad(set_to_none=True)
+        loss.backward()
+        opt.step()
+        first = first if first is not None else loss.item()
+        last = loss.item()
+        if step % 20 == 0 or step == args.overfit_steps - 1:
+            print(f"[overfit] step {step:4d} CE {loss.item():.4f}")
+    ok = last < 0.05
+    print(f"[overfit] CE {first:.3f} -> {last:.4f} | {'PASS' if ok else 'FAIL'} (threshold 0.05)")
+    return {"mode": "overfit", "lr": args.lr, "steps": args.overfit_steps,
+            "ce_first": first, "ce_last": last, "pass": ok}
+
+
+def run_train(args) -> dict:
+    set_seed(args.seed)
+    tokenizer, sets, model = build(args)
+    train_loader = make_loader(sets["train"], tokenizer, args.batch_size, shuffle=True, seed=args.seed)
+    val_loader = make_loader(sets["val"], tokenizer, args.eval_batch_size)
+    test_loader = make_loader(sets["test"], tokenizer, args.eval_batch_size)
+
+    steps_per_epoch = math.ceil(len(train_loader) / args.grad_accum)
+    total_steps = steps_per_epoch * args.epochs
+    opt = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=0.0)
+    sched = get_cosine_schedule_with_warmup(opt, int(0.03 * total_steps), total_steps)
+    n_params = sum(p.numel() for p in model.parameters())
+
+    best = {"val_ce": float("inf"), "epoch": -1, "state": None}
+    curves, tokens_seen, t0 = [], 0, time.time()
+    for epoch in range(args.epochs):
+        model.train()
+        running, running_tok = 0.0, 0
+        opt.zero_grad(set_to_none=True)
+        for i, (ids, labels, mask) in enumerate(train_loader):
+            ids, labels, mask = ids.to(args.device), labels.to(args.device), mask.to(args.device)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = model(input_ids=ids, attention_mask=mask).logits
+            shift_logits = logits[:, :-1].float()
+            shift_labels = labels[:, 1:]
+            ntok = (shift_labels != -100).sum()
+            loss_sum = F.cross_entropy(shift_logits.reshape(-1, shift_logits.size(-1)),
+                                       shift_labels.reshape(-1), ignore_index=-100, reduction="sum")
+            (loss_sum / ntok / args.grad_accum).backward()
+            running += loss_sum.item()
+            running_tok += ntok.item()
+            tokens_seen += mask.sum().item()
+            if (i + 1) % args.grad_accum == 0 or i == len(train_loader) - 1:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+                opt.step()
+                sched.step()
+                opt.zero_grad(set_to_none=True)
+        val_ce, _ = evaluate(model, val_loader, args.device)
+        train_ce = running / max(running_tok, 1)
+        curves.append({"epoch": epoch, "train_ce": train_ce, "val_ce": val_ce, "lr": sched.get_last_lr()[0]})
+        print(f"[train lr={args.lr} seed={args.seed}] epoch {epoch}: train CE {train_ce:.4f} | val CE {val_ce:.4f}")
+        if val_ce < best["val_ce"] - 1e-4:
+            best = {"val_ce": val_ce, "epoch": epoch,
+                    "state": {k: v.detach().cpu().clone() for k, v in model.state_dict().items()}}
+        elif epoch - best["epoch"] >= args.patience:
+            print(f"[train] early stop at epoch {epoch} (best val CE {best['val_ce']:.4f} @ epoch {best['epoch']})")
+            break
+
+    assert best["state"] is not None, "no best checkpoint recorded"
+    model.load_state_dict(best["state"])
+    model.to(args.device)
+    test_ce, test_tok = evaluate(model, test_loader, args.device)
+    test_ce_full, _ = evaluate(model, test_loader, args.device, full_sequence=True)
+    result = {
+        "mode": "train", "model": args.model, "n_params": n_params, "lr": args.lr, "seed": args.seed,
+        "max_seq_len": args.max_seq_len, "batch_size": args.batch_size, "grad_accum": args.grad_accum,
+        "effective_batch": args.batch_size * args.grad_accum, "epochs_max": args.epochs,
+        "epochs_ran": len(curves), "best_epoch": best["epoch"], "patience": args.patience,
+        "val_ce": best["val_ce"], "test_ce": test_ce, "test_ppl": math.exp(test_ce),
+        "test_ce_full_seq": test_ce_full, "test_target_tokens": test_tok,
+        "tokens_seen": tokens_seen, "flops_est_6ND": 6 * n_params * tokens_seen,
+        "runtime_s": round(time.time() - t0, 1), "curves": curves,
+        "data_stats": {k: v.stats() for k, v in sets.items()},
+        "tokenizer": args.model, "weight_decay": 0.0, "warmup_ratio": 0.03, "lr_schedule": "cosine",
+        "grad_clip": 1.0, "precision": "bf16 autocast, fp32 master weights",
+    }
+    print(f"[train] DONE lr={args.lr} seed={args.seed}: val CE {best['val_ce']:.4f} | "
+          f"test CE {test_ce:.4f} (ppl {math.exp(test_ce):.1f}) | full-seq {test_ce_full:.4f}")
+    return result
+
+
+def run_aggregate(args) -> dict:
+    res_dir = Path(args.results_dir)
+    runs = [json.loads(p.read_text()) for p in sorted(res_dir.glob("*.json"))]
+    zero = next((r for r in runs if r["mode"] == "zeroshot"), None)
+    trains = [r for r in runs if r["mode"] == "train"]
+    sweep = [r for r in trains if r["seed"] == args.seed_sweep]
+    by_lr = sorted(sweep, key=lambda r: r["val_ce"])
+    best_lr = by_lr[0]["lr"] if by_lr else None
+    finals = [r for r in trains if r["lr"] == best_lr]
+    lines = [
+        "# B1 results — LM + SFT on VeriBench train/val/test",
+        "",
+        f"**TLDR:** {finals[0]['model'] if finals else '?'} full-SFT on VB-train (707 tasks): "
+        f"test completion-CE {np.mean([r['test_ce'] for r in finals]):.4f} ± {np.std([r['test_ce'] for r in finals]):.4f} nats "
+        f"(ppl {np.mean([r['test_ppl'] for r in finals]):.2f}) over {len(finals)} seeds vs zero-shot "
+        f"{zero['test_ce'] if zero else float('nan'):.4f} nats (ppl {zero['test_ppl'] if zero else float('nan'):.1f}). "
+        if finals else "**TLDR:** incomplete — missing final runs.",
+        "",
+        "Completion-only CE (prompt tokens masked) in nats; ppl = exp(CE). Full protocol: `PROMPT.md`.",
+        "",
+        "## LR sweep (seed 0, early stop on val CE)",
+        "",
+        "| LR | epochs ran | best epoch | val CE | test CE* |",
+        "|---|---|---|---|---|",
+    ]
+    for r in sorted(sweep, key=lambda r: r["lr"]):
+        lines.append(f"| {r['lr']:g} | {r['epochs_ran']} | {r['best_epoch']} | {r['val_ce']:.4f} | {r['test_ce']:.4f} |")
+    lines += ["", "*test CE shown for completeness; best LR was selected on val only.", ""]
+    if finals:
+        f0 = finals[0]
+        lines += [
+            f"## Final: best LR = {best_lr:g} × {len(finals)} seeds",
+            "",
+            "| model | params | LR | sched | eff. batch | max epochs | best epoch (per seed) | tokens seen (mean) | "
+            "val CE (mean±std) | **test CE (mean±std)** | test ppl | full-seq test CE | zero-shot test CE |",
+            "|---|---|---|---|---|---|---|---|---|---|---|---|---|",
+            "| {model} | {params:.0f}M | {lr:g} | cosine, wu 3% | {eb} | {me} | {be} | {tok:.2e} | "
+            "{vm:.4f}±{vs:.4f} | **{tm:.4f}±{ts:.4f}** | {pm:.2f} | {fm:.4f} | {z:.4f} |".format(
+                model=f0["model"], params=f0["n_params"] / 1e6, lr=best_lr, eb=f0["effective_batch"],
+                me=f0["epochs_max"], be=",".join(str(r["best_epoch"]) for r in finals),
+                tok=float(np.mean([r["tokens_seen"] for r in finals])),
+                vm=np.mean([r["val_ce"] for r in finals]), vs=np.std([r["val_ce"] for r in finals]),
+                tm=np.mean([r["test_ce"] for r in finals]), ts=np.std([r["test_ce"] for r in finals]),
+                pm=np.mean([r["test_ppl"] for r in finals]),
+                fm=np.mean([r["test_ce_full_seq"] for r in finals]),
+                z=zero["test_ce"] if zero else float("nan"),
+            ),
+            "",
+            f"FLOPs estimate (6·N·D): {np.mean([r['flops_est_6ND'] for r in finals]):.2e} per final run. "
+            f"Truncation at max_seq_len {f0['max_seq_len']}: "
+            f"{f0['data_stats']['train']['n_prompt_truncated']} prompt-truncated, "
+            f"{f0['data_stats']['train']['n_target_truncated']} target-truncated of "
+            f"{f0['data_stats']['train']['n_examples']} train examples; "
+            f"{f0['data_stats']['train']['n_skipped_unpaired']}/1/1 unpaired rows skipped (train/val/test).",
+        ]
+    lines += [
+        "",
+        "## Repro",
+        "```bash",
+        "python train_b1.py --mode zeroshot",
+        "python train_b1.py --mode overfit --lr 5e-5",
+        "for lr in 1e-5 2e-5 5e-5; do python train_b1.py --mode train --lr $lr --seed 0; done",
+        f"for s in 0 1 2; do python train_b1.py --mode train --lr {best_lr:g} --seed $s; done" if best_lr else "",
+        "python train_b1.py --mode aggregate",
+        "```",
+    ]
+    out_path = res_dir.parent / "results_b1.md"
+    out_path.write_text("\n".join(lines) + "\n")
+    print(f"[aggregate] wrote {out_path}")
+    return {"mode": "aggregate", "best_lr": best_lr, "n_final_seeds": len(finals)}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--mode", required=True, choices=["zeroshot", "overfit", "train", "aggregate"])
+    p.add_argument("--data-dir", default=str(Path(__file__).resolve().parent.parent / "08_vb_train_val_test" / "splits"))
+    p.add_argument("--results-dir", default=str(Path(__file__).resolve().parent / "results"))
+    p.add_argument("--model", default="Qwen/Qwen2.5-0.5B")
+    p.add_argument("--max-seq-len", type=int, default=4096)
+    p.add_argument("--lr", type=float, default=2e-5)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--patience", type=int, default=2)
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--eval-batch-size", type=int, default=4)
+    p.add_argument("--grad-accum", type=int, default=4)
+    p.add_argument("--overfit-steps", type=int, default=150)
+    p.add_argument("--seed-sweep", type=int, default=0, help="seed used for the LR sweep (aggregate mode)")
+    args = p.parse_args()
+    args.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    if args.mode != "aggregate":
+        assert args.device == "cuda", "refusing to run on CPU — set CUDA_VISIBLE_DEVICES"
+
+    result = {"zeroshot": run_zeroshot, "overfit": run_overfit, "train": run_train, "aggregate": run_aggregate}[args.mode](args)
+
+    if args.mode in ("zeroshot", "train"):
+        res_dir = Path(args.results_dir)
+        res_dir.mkdir(parents=True, exist_ok=True)
+        name = "zeroshot.json" if args.mode == "zeroshot" else f"b1_lr{args.lr:g}_seed{args.seed}.json"
+        (res_dir / name).write_text(json.dumps(result, indent=2) + "\n")
+        print(f"[main] wrote {res_dir / name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**TLDR:** Ready-to-use VeriBench train/val/test split (`experiments/08_vb_train_val_test/`, 707/87/97 gold tasks with `py_code`+`lean_text` embedded) + both CE baselines run for real on skampere2 (1× H200 each): **B1** Qwen2.5-0.5B SFT → **test completion-CE 0.3124 ± 0.0008 nats (ppl 1.37)** vs 1.1485 zero-shot; **B2** official EBT (from-scratch paper-recipe fallback, no public EBT checkpoints exist) → **2.7794 nats (ppl 16.1)**. @eobbad it's ready — run instructions below.

## Summary
- `08_vb_train_val_test/`: portable 3-way split, task-level SHA-256 bucketing, assignment identical to the 2026-05-26 split (0/1258 mismatches); SCSC-compatible `task_name`s; +368 agent variants as EBT negatives. QA: Gemini A2 review PASS, 0 critical.
- `09_vb_ce_baselines/PROMPT.md`: the meeting prompt with placeholders filled (`MAX_SEQ_LEN` raised to 4096 — 2048 would truncate ~50% of pairs; train is 707, not "~200").
- `09_vb_ce_baselines/train_b1.py` + `run_b1.sh`: full SFT pipeline — zero-shot ref, single-batch overfit sanity, LR sweep {1,2,5}e-5 with val early-stop, best-LR × 3 seeds, aggregate → `results_b1.md`.
- B1 result: completion-only test CE **0.3124 ± 0.0008** (ppl 1.37), full-seq 0.6695, zero-shot ref 1.1485; ~9 min/run on 1× H200.
- `09_vb_ce_baselines/ebt_integration/` + `run_b2.sh` + `eval_b2.py`: pinned `alexiglad/EBT@19420cb` + idempotent patcher registering a `veribench` dataset (same formatting/tokenizer as B1), driver, and a protocol-metric evaluator for their checkpoints.
- B2 result (`results_b2.md`): EBT-xxs (131M) **from scratch** — the repo's finetune mode needs a pretrained ckpt and none are released, so the prompt's fallback applies and is stated explicitly — best-val ckpt test CE **2.7794** (ppl 16.1); no NaN/divergence; the B1 gap is pretrained-vs-scratch, **not** an architecture comparison.
- Fixed a real data bug found during B2: `prompt[-0:]` negative-zero slice kept the whole prompt when a target is exactly max_len (audited: 1 B2 doc, 0 B1 items → B1 numbers unaffected).
- Caveats logged in `results_b2.md`: B2 is 1 seed, ctx 2048 (EBT MCMC OOMs at 4096 even on 143 GB), 131M vs 494M params, ~19.4M vs 6.1M tokens at selection.

## How to run (@eobbad)
```bash
git clone -b vb-ce-baselines-elyas https://github.com/brando90/free-energy && cd free-energy
# data is self-contained jsonl: experiments/08_vb_train_val_test/splits/{train,val,test}.jsonl
uv venv .venv && . .venv/bin/activate && uv pip install torch transformers numpy
cd experiments/09_vb_ce_baselines
bash run_b1.sh 0                 # full B1 pipeline on GPU 0 (~1 h): writes results_b1.md
# B2 (official EBT, extra deps): pytorch-lightning wandb datasets opencv-python-headless einops torchvision diffusers matplotlib nltk
bash run_b2.sh 0 1400            # trains EBT-xxs from scratch (~2 h), ckpts under EBT/logs/checkpoints/
python eval_b2.py --ckpt <EBT>/logs/checkpoints/<run>/ --split test
```
Schema/loading docs: `experiments/08_vb_train_val_test/README.md` (CE + SCSC usage, gotchas).

## Test plan
- B1: single-batch overfit CE → 0.0000 (PASS); SFT delta vs zero-shot 1.1485 → 0.3124; 3-seed std 0.0008.
- B2: eval smoke on a 3-step ckpt gives CE ≈ ln|V| (uniform — correct plumbing); best-val and last ckpts agree to 1e-4.
- Split: Gemini A2 QA PASS (0 critical); content sha-verified against `~/veribench/veribench_dataset`; 0 cross-split leakage.

Links: [results_b1.md](https://github.com/brando90/free-energy/blob/vb-ce-baselines-elyas/experiments/09_vb_ce_baselines/results_b1.md) · [results_b2.md](https://github.com/brando90/free-energy/blob/vb-ce-baselines-elyas/experiments/09_vb_ce_baselines/results_b2.md) · [split README](https://github.com/brando90/free-energy/blob/vb-ce-baselines-elyas/experiments/08_vb_train_val_test/README.md) · [EBT paper](https://arxiv.org/abs/2507.02092) · [2026-06-09 meeting](https://fathom.video/share/GsBj2jyUo3Xo_pNaqWdvoZ4Ud4SXgdfv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
